### PR TITLE
[bugfix]修改了modules/utils.py中`initial_parameter()`函数的bug

### DIFF
--- a/fastNLP/modules/utils.py
+++ b/fastNLP/modules/utils.py
@@ -66,7 +66,10 @@ def initial_parameter(net, initial_method=None):
                     init.normal_(w.data)  # bias
         elif m is not None and hasattr(m, 'weight') and \
                 hasattr(m.weight, "requires_grad"):
-            init_method(m.weight.data)
+                if len(w.data.size()) > 1:
+                    init_method(m.weight.data)
+                else:
+                    init.normal_(m.weight.data)  # batchnorm or layernorm
         else:
             for w in m.parameters():
                 if w.requires_grad:

--- a/fastNLP/modules/utils.py
+++ b/fastNLP/modules/utils.py
@@ -66,7 +66,7 @@ def initial_parameter(net, initial_method=None):
                     init.normal_(w.data)  # bias
         elif m is not None and hasattr(m, 'weight') and \
                 hasattr(m.weight, "requires_grad"):
-                if len(w.data.size()) > 1:
+                if len(m.weight.size()) > 1:
                     init_method(m.weight.data)
                 else:
                     init.normal_(m.weight.data)  # batchnorm or layernorm


### PR DESCRIPTION
Description：
修改了modules/utils.py中`initial_parameter()`函数的bug

Main reason: 
函数默认情况下使用`init.xavier_normal_()`初始化，但例如BatchNorm和LayerNorm这样的参数维度为1的层是不能使用这种初始化的。

报错为`ValueError: Fan in and fan out can not be computed for tensor with less than 2 dimensions`。

-	[x] The PR title starts with [$CATEGORY] (例如[bugfix]修复bug，[new]添加新功能，[test]修改测试，[rm]删除旧代码)
-	[x] Changes are complete (i.e. I finished coding on this PR)  修改完成才提PR
-	[x] All changes have test coverage  修改的部分顺利通过测试。对于fastnlp/fastnlp/*的修改，测试代码**必须**提供在fastnlp/test/*。
-	[x] Code is well-documented  注释写好，API文档会从注释中抽取
-	[x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change  修改导致例子或tutorial有变化，请找核心开发人员

Changes: 逐项描述修改的内容
- 当参数维度为1时使用`init.normal_()`初始化。

Mention: 找人review你的PR

@xpqiu