### PR TITLE
"bugs:fix lstm rnn.pack_padded_sequence RuntimeError, 详细信息: https://g…

### DIFF
--- a/fastNLP/modules/encoder/lstm.py
+++ b/fastNLP/modules/encoder/lstm.py
@@ -70,7 +70,7 @@ class LSTM(nn.Module):
                 x = x[sort_idx]
             else:
                 x = x[:, sort_idx]
-            x = rnn.pack_padded_sequence(x, sort_lens, batch_first=self.batch_first)
+            x = rnn.pack_padded_sequence(x, sort_lens.cpu(), batch_first=self.batch_first)
             output, hx = self.lstm(x, hx)  # -> [N,L,C]
             output, _ = rnn.pad_packed_sequence(output, batch_first=self.batch_first, total_length=max_len)
             _, unsort_idx = torch.sort(sort_idx, dim=0, descending=False)


### PR DESCRIPTION
…ithub.com/pytorch/pytorch/issues/43227"

Description：简要描述这次PR的内容
一个torch的bug:
nn.utils.rnn.pack_padded_sequence: RuntimeError: 'lengths' argument should be a 1D CPU int64 tensor, but got 1D cuda:0 Long tensor
详情查看:
https://github.com/pytorch/pytorch/issues/43227

Main reason: 做出这次修改的原因
兼容torch 1.70 GPU版本


Checklist  检查下面各项是否完成

Please feel free to remove inapplicable items for your PR.

-	[bugfix] The PR title starts with [$CATEGORY] (例如[bugfix]修复bug，[new]添加新功能，[test]修改测试，[rm]删除旧代码)
-	[ ] Changes are complete (i.e. I finished coding on this PR)  修改完成才提PR
-	[ ] All changes have test coverage  修改的部分顺利通过测试。对于fastnlp/fastnlp/*的修改，测试代码**必须**提供在fastnlp/test/*。
-	[ ] Code is well-documented  注释写好，API文档会从注释中抽取
-	[ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change  修改导致例子或tutorial有变化，请找核心开发人员

Changes: 逐项描述修改的内容
- torch pack_padded_sequence函数兼容torch1.7.0 cuda 版本

Mention: 找人review你的PR

@修改过这个文件的人
@核心开发人员
