### PR TITLE
Flaky test fix

### DIFF
--- a/tests/core/test_batch.py
+++ b/tests/core/test_batch.py
@@ -445,7 +445,7 @@ class TestCase1(unittest.TestCase):
         sample_count = 0
         for batch_x, batch_y in data_iter:
             sample_count += len(batch_x['seq_len'])
-            self.assertTrue(sum(batch_x['seq_len'])<120)
+            self.assertTrue(sum(batch_x['seq_len'])<=120)
         self.assertEqual(sample_count, num_samples)
 
     """


### PR DESCRIPTION
Hi, 

The test `test_ConstantTokenNumSampler` sometimes fails when the value of `sum(batch_x['seq_len'])` equals exactly 120. This PR fixes this issue.

To find a solution, I collected samples from several test executions and computed the tail distribution. I computed the extreme percentiles to check how high can the values be. The 99.99th percentile seems to be converging to 120. Changing the operator to '<=' will solve this issue.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions. Also, here I assume there are no bugs in the code under test.