### PR TITLE
[bugfix]修复Trainer里check_code函数忽略pin_memory参数导致的内存不足bug

### DIFF
--- a/fastNLP/core/tester.py
+++ b/fastNLP/core/tester.py
@@ -113,7 +113,7 @@ class Tester(object):
         self.verbose = verbose
         self.use_tqdm = use_tqdm
         self.logger = logger
-        self.pin_memory = kwargs.get('pin_memory', True)
+        self.pin_memory = kwargs.get('pin_memory', False if parse_version(torch.__version__)==parse_version('1.9') else True)
 
         if isinstance(data, DataSet):
             sampler = kwargs.get('sampler', None)


### PR DESCRIPTION
Description：修复Trainer里check_code函数忽略pin_memory参数导致的内存不足bug

Main reason: 
在使用fastNLP库时发生内存不足错误。使用场景是在使用CPU训练模型时，发生了内存错误。经过DEBUG发现，是core/Trainer.py文件里，_check_code函数在调用Tester类时没有指定pin_memory参数，那么Tester类默认初始化pin_memory为True。


Checklist  检查下面各项是否完成

Please feel free to remove inapplicable items for your PR.

-	[x] The PR title starts with [$CATEGORY] (例如[bugfix]修复bug，[new]添加新功能，[test]修改测试，[rm]删除旧代码)
-	[x] Changes are complete (i.e. I finished coding on this PR)  修改完成才提PR
-	[x] All changes have test coverage  修改的部分顺利通过测试。对于fastnlp/fastnlp/*的修改，测试代码**必须**提供在fastnlp/test/*。
-	[x] Code is well-documented  注释写好，API文档会从注释中抽取
-	[x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change  修改导致例子或tutorial有变化，请找核心开发人员

Changes: 逐项描述修改的内容
- 给core/trainer.py里的_check_code函数增加了一个pin_memory参数

Mention: 找人review你的PR

@修改过这个文件的人
@核心开发人员
