### PR TITLE
[bugfix]修复Tester初始化bug

### DIFF
--- a/fastNLP/core/tester.py
+++ b/fastNLP/core/tester.py
@@ -148,7 +148,7 @@ class Tester(object):
                 self._predict_func = self._model.predict
                 self._predict_func_wrapper = self._model.predict
         else:
-            if _model_contains_inner_module(model):
+            if _model_contains_inner_module(self._model):
                 self._predict_func_wrapper = self._model.forward
                 self._predict_func = self._model.module.forward
             else:


### PR DESCRIPTION
Description：修复Tester初始化bug

Main reason: 
core/tester.py里Tester类的初始化方法有一个很明显的bug
https://github.com/fastnlp/fastNLP/blob/3cb01d15d8bc7d10f292b12e8fa803087d37e887/fastNLP/core/tester.py#L151
这里应该改为
```python
            if _model_contains_inner_module(self._model):
```
因为
https://github.com/fastnlp/fastNLP/blob/3cb01d15d8bc7d10f292b12e8fa803087d37e887/fastNLP/core/tester.py#L111
且它上下文里其他部分：
https://github.com/fastnlp/fastNLP/blob/3cb01d15d8bc7d10f292b12e8fa803087d37e887/fastNLP/core/tester.py#L135-L156
都用的是`self._model`

Checklist  检查下面各项是否完成

Please feel free to remove inapplicable items for your PR.

-	[x] The PR title starts with [$CATEGORY] (例如[bugfix]修复bug，[new]添加新功能，[test]修改测试，[rm]删除旧代码)
-	[x] Changes are complete (i.e. I finished coding on this PR)  修改完成才提PR
-	[x] All changes have test coverage  修改的部分顺利通过测试。对于fastnlp/fastnlp/*的修改，测试代码**必须**提供在fastnlp/test/*。
-	[x] Code is well-documented  注释写好，API文档会从注释中抽取
-	[x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change  修改导致例子或tutorial有变化，请找核心开发人员

Changes: 
- 修复Tester类初始化bug

Mention: 

@yhcc 
