### PR TITLE
[bugfix] 支持 Jittor single driver，并添加测试用例

### DIFF
--- a/fastNLP/core/drivers/jittor_driver/jittor_driver.py
+++ b/fastNLP/core/drivers/jittor_driver/jittor_driver.py
@@ -33,10 +33,11 @@ class JittorDriver(Driver):
                              f"`jittor.Module` type.")
         super(JittorDriver, self).__init__(model)
 
-        self.model = model
-
         self.auto_cast, _grad_scaler = _build_fp16_env(dummy=not fp16)
         self.grad_scaler = _grad_scaler()
+
+        # 用来设置是否关闭 auto_param_call 中的参数匹配问题；
+        self.wo_auto_param_call = kwargs.get("model_wo_auto_param_call", False)
 
     @staticmethod
     def check_dataloader_legality(dataloader, dataloader_name, is_train: bool = False):

--- a/fastNLP/core/drivers/jittor_driver/single_device.py
+++ b/fastNLP/core/drivers/jittor_driver/single_device.py
@@ -60,8 +60,8 @@ class JittorSingleDriver(JittorDriver):
             logger.debug(f'Use {_get_fun_msg(fn, with_fp=False)}...')
             return fn, None
         elif fn in {"train_step", "evaluate_step"}:
-            logger.debug(f'Use {_get_fun_msg(self.model.forward, with_fp=False)}...')
-            return self.model, self.model.forward
+            logger.debug(f'Use {_get_fun_msg(self.model.execute, with_fp=False)}...')
+            return self.model, self.model.execute
         else:
             raise RuntimeError(f"There is no `{fn}` method in your {type(self.model)}.")
 
@@ -98,3 +98,9 @@ class JittorSingleDriver(JittorDriver):
                 return dataloader
         else:
             return dataloader
+
+    def setup(self):
+        """
+        使用单个 GPU 时，jittor 底层自动实现调配，无需额外操作
+        """
+        pass

--- a/tests/core/controllers/test_trainer_jittor.py
+++ b/tests/core/controllers/test_trainer_jittor.py
@@ -1,0 +1,133 @@
+import pytest
+
+from fastNLP.core.controllers.trainer import Trainer
+from fastNLP.core.controllers.trainer import Evaluator
+from fastNLP.core.metrics.accuracy import Accuracy
+from fastNLP.core.callbacks.progress_callback import RichCallback
+from fastNLP.core.dataloaders.jittor_dataloader.fdl import JittorDataLoader
+from fastNLP.envs.imports import _NEED_IMPORT_JITTOR
+
+if _NEED_IMPORT_JITTOR:
+    import jittor as jt
+    from jittor import nn, Module
+    from jittor.dataset import Dataset
+
+
+class JittorNormalModel_Classification(Module):
+    """
+    基础的 Jittor 分类模型
+    """
+
+    def __init__(self, num_labels, feature_dimension):
+        super(JittorNormalModel_Classification, self).__init__()
+        self.num_labels = num_labels
+
+        self.linear1 = nn.Linear(in_features=feature_dimension, out_features=64)
+        self.ac1 = nn.ReLU()
+        self.linear2 = nn.Linear(in_features=64, out_features=32)
+        self.ac2 = nn.ReLU()
+        self.output = nn.Linear(in_features=32, out_features=num_labels)
+        self.loss_fn = nn.CrossEntropyLoss()
+
+    def execute(self, x):
+        # It's similar to forward function in Pytorch
+        x = self.ac1(self.linear1(x))
+        x = self.ac2(self.linear2(x))
+        x = self.output(x)
+        return x
+
+    def train_step(self, x, y):
+        x = self(x)
+        return {"loss": self.loss_fn(x, y)}
+
+    def evaluate_step(self, x, y):
+        x = self(x)
+        return {"pred": x, "target": y.reshape((-1,))}
+
+
+class JittorRandomMaxDataset(Dataset):
+    def __init__(self, num_samples, num_features):
+        super(JittorRandomMaxDataset, self).__init__()
+        self.x = jt.randn((num_samples, num_features))
+        self.y = self.x.argmax(dim=1)[0]
+
+    def __len__(self):
+        return len(self.y)
+
+    def __getitem__(self, item):
+        return {"x": self.x[item], "y": self.y[item]}
+
+
+class TrainJittorConfig:
+    num_labels: int = 5
+    feature_dimension: int = 5
+    lr = 1e-1
+    batch_size: int = 4
+    shuffle: bool = True
+
+
+@pytest.mark.parametrize("driver,device", [("jittor", None)])
+@pytest.mark.parametrize("callbacks", [[RichCallback(100)]])
+def test_trainer_jittor(
+        driver,
+        device,
+        callbacks,
+        n_epochs=3,
+):
+    model = JittorNormalModel_Classification(
+        num_labels=TrainJittorConfig.num_labels,
+        feature_dimension=TrainJittorConfig.feature_dimension
+    )
+    optimizer = nn.SGD(model.parameters(), lr=TrainJittorConfig.lr)
+    train_dataloader = JittorDataLoader(
+        dataset=JittorRandomMaxDataset(1000, TrainJittorConfig.feature_dimension),
+        batch_size=TrainJittorConfig.batch_size,
+        shuffle=True,
+        # num_workers=4,
+    )
+    val_dataloader = JittorDataLoader(
+        dataset=JittorRandomMaxDataset(500, TrainJittorConfig.feature_dimension),
+        batch_size=TrainJittorConfig.batch_size,
+        shuffle=True,
+        # num_workers=4,
+    )
+    test_dataloader = JittorDataLoader(
+        dataset=JittorRandomMaxDataset(1000, TrainJittorConfig.feature_dimension),
+        batch_size=TrainJittorConfig.batch_size,
+        shuffle=True,
+        # num_workers=4,
+    )
+    metrics = {"acc": Accuracy()}
+
+    trainer = Trainer(
+        model=model,
+        driver=driver,
+        device=device,
+        optimizers=optimizer,
+        train_dataloader=train_dataloader,
+        evaluate_dataloaders=val_dataloader,
+        validate_every=-1,
+        evaluate_fn="evaluate_step",
+        input_mapping=None,
+        output_mapping=None,
+        metrics=metrics,
+        n_epochs=n_epochs,
+        callbacks=callbacks,
+        # progress_bar="rich"
+    )
+    trainer.run()
+
+    evaluator = Evaluator(
+        model=model,
+        driver=driver,
+        dataloaders=test_dataloader,
+        evaluate_fn="evaluate_step",
+        metrics=metrics,
+    )
+    metric_results = evaluator.run()
+    assert metric_results["acc#acc"] > 0.80
+
+
+if __name__ == "__main__":
+    # test_trainer_jittor("jittor", None, [RichCallback(100)])
+    pytest.main(['test_trainer_jittor.py'])  # 只运行此模块


### PR DESCRIPTION
Description: 支持 Jittor single driver，并添加测试用例

Main reason: 无法通过 Trainer 跑通 Jittor single driver。此次更新，支持 Jittor single driver，并添加对应 Trainer 的测试用例


Checklist  检查下面各项是否完成

-	[x] The PR title starts with [$CATEGORY] (例如[bugfix]修复bug，[new]添加新功能，[test]修改测试，[rm]删除旧代码)
-	[x] Changes are complete (i.e. I finished coding on this PR)  修改完成才提PR
-	[x] All changes have test coverage  修改的部分顺利通过测试。对于fastnlp/fastnlp/*的修改，测试代码**必须**提供在fastnlp/test/*。
-	[x] Code is well-documented  注释写好，API文档会从注释中抽取
-	[x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change  修改导致例子或tutorial有变化，请找核心开发人员

Changes: 
- fastNLP/core/drivers/jittor_driver/jittor_driver.py 中修改初始化函数 
![image](https://user-images.githubusercontent.com/73881739/167237982-b17469f3-0fa2-423e-925d-d53e34e5ddb8.png)

- fastNLP/core/drivers/jittor_driver/single_device.py 中更改默认调用的 forward 函数为 execute 函数
- fastNLP/core/drivers/jittor_driver/single_device.py 中实现父类抽象函数 setup
![image](https://user-images.githubusercontent.com/73881739/167238049-51912778-77ea-4769-939b-75f1453a4f67.png)

- 添加文件 tests/core/controllers/test_trainer_jittor.py，添加对应 pytest 测试用例，通过 Trainer 测 Jittor single driver。该测试中，断言模型训练效果：准确率在80%以上。测试用时约 1.5s。


Mention: 

@x54-729
@yhcc 
