### PR TITLE
[bugfix] 修复 tests/core/controllers/_test_trainer_jittor.py，使其可以正常运行

### DIFF
--- a/fastNLP/core/drivers/jittor_driver/single_device.py
+++ b/fastNLP/core/drivers/jittor_driver/single_device.py
@@ -8,7 +8,7 @@ from fastNLP.core.samplers import ReproducibleBatchSampler, ReproducibleSampler
 from fastNLP.core.log import logger
 
 if _NEED_IMPORT_JITTOR:
-    import jittor
+    import jittor as jt
 
 __all__ = [
     "JittorSingleDriver",
@@ -105,6 +105,9 @@ class JittorSingleDriver(JittorDriver):
 
     def setup(self):
         """
-        使用单个 GPU 时，jittor 底层自动实现调配，无需额外操作
+        支持 cpu 和 gpu 的切换
         """
-        pass
+        if self.model_device in ["cpu", None]:
+            jt.flags.use_cuda = 0   # 使用 cpu
+        else:
+            jt.flags.use_cuda = 1   # 使用 cuda

--- a/tests/core/controllers/_test_trainer_jittor.py
+++ b/tests/core/controllers/_test_trainer_jittor.py
@@ -225,7 +225,7 @@ if __name__ == "__main__":
         device=[0,1,2,3,4],
         optimizers=optimizer,
         train_dataloader=train_dataloader,
-        validate_dataloaders=val_dataloader,
+        evaluate_dataloaders=val_dataloader,
         validate_every=-1,
         input_mapping=None,
         output_mapping=None,

--- a/tests/core/controllers/test_trainer_jittor.py
+++ b/tests/core/controllers/test_trainer_jittor.py
@@ -69,7 +69,8 @@ class TrainJittorConfig:
     shuffle: bool = True
 
 
-@pytest.mark.parametrize("driver,device", [("jittor", None)])
+@pytest.mark.parametrize("driver", ["jittor"])
+@pytest.mark.parametrize("device", ["cpu", 1])
 @pytest.mark.parametrize("callbacks", [[RichCallback(100)]])
 @pytest.mark.jittor
 def test_trainer_jittor(
@@ -134,4 +135,5 @@ def test_trainer_jittor(
 
 if __name__ == "__main__":
     # test_trainer_jittor("jittor", None, [RichCallback(100)])
+    # test_trainer_jittor("jittor", 1, [RichCallback(100)])
     pytest.main(['test_trainer_jittor.py'])  # 只运行此模块


### PR DESCRIPTION
Description：修复 tests/core/controllers/_test_trainer_jittor.py，使其可以正常运行。将传入 Trainer 的 validate_dataloaders 参数，改为 evaluate_dataloaders 即可。

Main reason: Trainer 不接收 validate_dataloaders 参数，改为 evaluate_dataloaders 即可。

Checklist  检查下面各项是否完成

Please feel free to remove inapplicable items for your PR.

-	[x] The PR title starts with [$CATEGORY] (例如[bugfix]修复bug，[new]添加新功能，[test]修改测试，[rm]删除旧代码)
-	[x] Changes are complete (i.e. I finished coding on this PR)  修改完成才提PR
-	[x] All changes have test coverage  修改的部分顺利通过测试。对于fastnlp/fastnlp/*的修改，测试代码**必须**提供在fastnlp/test/*。
-	[x] Code is well-documented  注释写好，API文档会从注释中抽取
-	[x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change  修改导致例子或tutorial有变化，请找核心开发人员

Changes: 将传入 Trainer 的 validate_dataloaders 参数，改为 evaluate_dataloaders 

Mention: 

@x54-729 
@yhcc 
