### PR TITLE
[new] 实现 jittor driver 多卡训练

### DIFF
--- a/fastNLP/core/drivers/jittor_driver/initialize_jittor_driver.py
+++ b/fastNLP/core/drivers/jittor_driver/initialize_jittor_driver.py
@@ -1,5 +1,6 @@
 from typing import Union, List
 
+from fastNLP.core.drivers.jittor_driver.mpi import JittorMPIDriver
 from fastNLP.core.drivers.jittor_driver.jittor_driver import JittorDriver
 from fastNLP.core.drivers.jittor_driver.single_device import JittorSingleDriver
 from fastNLP.envs.imports import _NEED_IMPORT_JITTOR
@@ -29,7 +30,11 @@ def initialize_jittor_driver(driver: str, device: Union[str, int, List[int]], mo
         raise ValueError("Parameter `driver` can only be one of these values: ['jittor'].")
 
     # TODO 实现更详细的判断
-    if driver == "jittor":
+    if device in ["cpu", "gpu", "cuda", "cuda:0", 0, None]:
         return JittorSingleDriver(model, device, **kwargs)
+    elif type(device) is int:
+        return JittorMPIDriver(model, device, **kwargs)
+    elif type(device) is list:
+        return JittorMPIDriver(model, device, **kwargs)
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"Device={device}")

--- a/tests/core/controllers/test_trainer_jittor.py
+++ b/tests/core/controllers/test_trainer_jittor.py
@@ -70,7 +70,7 @@ class TrainJittorConfig:
 
 
 @pytest.mark.parametrize("driver", ["jittor"])
-@pytest.mark.parametrize("device", ["cpu", 1])
+@pytest.mark.parametrize("device", ["cpu", "gpu", "cuda:0"])
 @pytest.mark.parametrize("callbacks", [[RichCallback(100)]])
 @pytest.mark.jittor
 def test_trainer_jittor(
@@ -134,6 +134,8 @@ def test_trainer_jittor(
 
 
 if __name__ == "__main__":
-    # test_trainer_jittor("jittor", None, [RichCallback(100)])
-    # test_trainer_jittor("jittor", 1, [RichCallback(100)])
+    # test_trainer_jittor("jittor", "cpu", [RichCallback(100)])         # 测试 CPU
+    # test_trainer_jittor("jittor", "cuda:0", [RichCallback(100)])      # 测试 单卡 GPU
+    # test_trainer_jittor("jittor", 1, [RichCallback(100)])             # 测试 指定 GPU
+    # test_trainer_jittor("jittor", [0, 1], [RichCallback(100)])        # 测试 多卡 GPU
     pytest.main(['test_trainer_jittor.py'])  # 只运行此模块


### PR DESCRIPTION
Description：利用 mpi，实现 jittor driver 多卡训练

Main reason: 需实现 jittor driver 多卡训练


Checklist  检查下面各项是否完成

Please feel free to remove inapplicable items for your PR.

-	[x] The PR title starts with [$CATEGORY] (例如[bugfix]修复bug，[new]添加新功能，[test]修改测试，[rm]删除旧代码)
-	[x] Changes are complete (i.e. I finished coding on this PR)  修改完成才提PR
-	[x] All changes have test coverage  修改的部分顺利通过测试。对于fastnlp/fastnlp/*的修改，测试代码**必须**提供在fastnlp/test/*。
-	[x] Code is well-documented  注释写好，API文档会从注释中抽取
-	[x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change  修改导致例子或tutorial有变化，请找核心开发人员

Changes: 
- 修改 fastNLP/core/drivers/jittor_driver/initialize_jittor_driver.py 中初始化 driver 的代码，根据不同的 device，对应实例化 JittorSingleDriver 和 JittorMPIDriver。
![image](https://user-images.githubusercontent.com/73881739/170243258-9c12ad3f-aea3-4d0d-9a2b-7eef2f310129.png)

- 完成 fastNLP/core/drivers/jittor_driver/mpi.py 代码。主要通过  __fork_with_mpi__ 方法，实现 jittor driver 多卡训练。
![image](https://user-images.githubusercontent.com/73881739/170243464-8a8de5d2-e936-4c18-9751-ae0487a4ca3d.png)

- 修改对应测试文件 tests/core/controllers/test_trainer_jittor.py

Mention: 

@x54-729 
@yhcc 
