### PR TITLE
[new] 增加训练中进度条提供额外信息的能力。

### DIFF
--- a/fastNLP/core/callbacks/__init__.py
+++ b/fastNLP/core/callbacks/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     'RichCallback',
     'TqdmCallback',
     'RawTextCallback',
+    'BaseExtraInfoModel',
 
     "LRSchedCallback",
     'LoadBestModelCallback',
@@ -34,7 +35,7 @@ from .callback import Callback
 from .callback_event import Event, Filter
 from .callback_manager import CallbackManager
 from .checkpoint_callback import CheckpointCallback
-from .progress_callback import choose_progress_callback, ProgressCallback, RichCallback, TqdmCallback, RawTextCallback
+from .progress_callback import choose_progress_callback, ProgressCallback, RichCallback, TqdmCallback, RawTextCallback, BaseExtraInfoModel
 from .lr_scheduler_callback import LRSchedCallback
 from .load_best_model_callback import LoadBestModelCallback
 from .early_stop_callback import EarlyStopCallback

--- a/fastNLP/core/callbacks/progress_callback.py
+++ b/fastNLP/core/callbacks/progress_callback.py
@@ -1,14 +1,14 @@
 import json
-from typing import Union, List, Callable, Dict, Any
+from typing import Union, Dict, Any, Sequence
 
 __all__ = [
     'choose_progress_callback',
     'ProgressCallback',
     'RichCallback',
     'TqdmCallback',
-    'RawTextCallback'
+    'RawTextCallback',
+    'BaseExtraInfoModel'
 ]
-
 
 from .has_monitor_callback import HasMonitorCallback
 from fastNLP.core.utils import f_rich_progress, f_tqdm_progress
@@ -59,6 +59,62 @@ def choose_progress_callback(progress_bar: Union[str, ProgressCallback]) -> Prog
         return None
 
 
+class BaseExtraInfoModel(object):
+    r"""
+    用来处理 ``extra_show_keys`` 中要显示的额外信息的类。这个类的作用是当 log 的输出周期大于 1 的时候可以对数据进行累积相加，到输出的时候再求平均。
+    """
+    @staticmethod
+    def update(output_collection: Dict[str, Any], outputs: dict) -> None:
+        r"""
+        每个 batch 训练结束后调用，更新 output_collection 中的内容，使得 output_collection 中的内容是 outputs 中的内容的累积，默认为相加。
+
+        :param output_collection: 累积了每次训练的结果。
+        :param outputs: 一个 batch 的输出结果，已经根据提供的 ``extra_show_keys`` 进行了筛选，要将其累积到 ``output_collection`` 中。
+
+        """
+        for key in outputs.keys():
+            if key in output_collection.keys():
+                try:
+                    output_collection[key] += outputs[key]
+                except Exception as e:
+                    logger.rank_zero_warning(f"Error found when accumulating key:{key}. \
+                                             Variables of {type(output_collection[key])} cannot be added. \
+                                             Please design your own `update` function.")
+                    output_collection[key] = outputs[key]
+
+
+    @staticmethod
+    def get_stat(output_collection: Dict[str, Any], print_every: int) -> Dict:
+        r"""
+        每个 log 周期调用一次，将 output_collection 中的内容转换为需要显示的内容，默认为求平均。
+
+        :param output_collection: 累积了每次训练的结果。
+        :param print_every: log 周期，每隔多少个 batch 打印一次 log，可以用它来求平均。
+
+        """
+        if print_every > 1:
+            for key in output_collection.keys():
+                try:
+                    output_collection[key] /= print_every
+                except Exception as e:
+                    logger.rank_zero_warning(f"Error found when computing the average of key:{key}. \
+                                             Variables of {type(output_collection[key])} cannot be divided by an integer. \
+                                             Please design your own `get_stat` function.")
+        return output_collection
+
+
+def _get_beautiful_extra_string(extra_info_collection: dict, progress_type: str) -> str:
+    """
+    用户有额外信息需要打印的情况下，将额外信息转换为字符串。
+    """
+    original = ''.join([f", {key}:{value}" for key, value in extra_info_collection.items()])
+    if progress_type == 'rich':
+        original = original.replace(',', ',\n')
+    elif progress_type == 'tqdm':
+        # TODO 使用 TQDM 进度条时，额外信息过长，控制台太小时会导致额外信息显示不全，且无法和 RICH 一样通过换行规避。
+        pass
+    return original
+
 class RichCallback(ProgressCallback):
     """
     在训练过程中打印 *rich* progress bar 的 callback 。在 Trainer 中，默认就会使用这个 callback 来显示进度。如果需要定制这个 Callback 的
@@ -83,16 +139,23 @@ class RichCallback(ProgressCallback):
 
         * 为 ``str``
          从 train_step 的返回 的 dict 中寻找该名称的内容，如果找到则打印出来。
-        * 为 ``List[str]``
+        * 为 ``Sequence[str]``
          与 ``str`` 类似，但是可以打印多个内容。
-        * 为 ``Dict[str, Any]``
-         将该参数原封不动地打印出来。
-        * 为 ``Callable``
-         用户可以自定义一个函数，接受参数为 train_step 的返回的 dict，返回一个 ``dict`` 作为需要打印的内容。
+
+    :param: extra_info_model: 当打印周期不为 1 的情况，是否希望额外打印的字段在打印周期间累积。
+
+        * 为 ``None``
+         不累积，仅打印当前轮次的额外信息
+        * 为静态类 :class:`~fastNLP.core.callback.BaseExtraInfoModel` 及其子类，必须实现 ``update`` 和 ``get_stat`` 方法。
+         在未进行打印的轮次，将额外信息相加累积，并在输出前求平均。可以手动重写 ``update`` 和 ``get_stat`` 方法来实现自己的累积方式。
 
     """
-    def __init__(self, print_every:int = 1, loss_round_ndigit:int = 6, monitor:str=None, larger_better:bool=True,
-                 format_json=True, extra_show_keys: Union[str, List[str], Dict[str, Any], Callable, None]=None):
+
+    def __init__(self, print_every: int = 1, loss_round_ndigit: int = 6, monitor: str = None,
+                 larger_better: bool = True,
+                 format_json=True,
+                 extra_show_keys: Union[str, Sequence[str], None] = None,
+                 extra_info_model: Union[type, None] = BaseExtraInfoModel):
         super().__init__(monitor=monitor, larger_better=larger_better, must_have_monitor=False)
         self.print_every = print_every
         self.progress_bar = f_rich_progress
@@ -100,7 +163,15 @@ class RichCallback(ProgressCallback):
         self.loss = 0
         self.loss_round_ndigit = loss_round_ndigit
         self.format_json = format_json
-        self.extra_show_keys = extra_show_keys
+        # 用于在进度条中显示额外信息
+        self.extra_show_keys = extra_show_keys if isinstance(extra_show_keys, Sequence) or extra_show_keys is None \
+            else [extra_show_keys]
+        self.extra_info_model = extra_info_model
+        if not hasattr(self.extra_info_model, 'update') or not hasattr(self.extra_info_model, 'get_stat'):
+            logger.rank_zero_warning(f"Your manually defined ExtraInfoModel does not implement the method: \
+                    {', '.join([str(m) for m in ['update', 'get_stat'] if not hasattr(self.extra_info_model, m)])}.")
+            self.extra_info_model = BaseExtraInfoModel
+        self.extra_info_collection = None
 
     def on_after_trainer_initialized(self, trainer, driver):
         if not self.progress_bar.disable:
@@ -110,11 +181,12 @@ class RichCallback(ProgressCallback):
     def on_train_begin(self, trainer):
         self.task2id['epoch'] = self.progress_bar.add_task(description=f'Epoch:{trainer.cur_epoch_idx}',
                                                            total=trainer.n_epochs,
-                                                           completed=trainer.global_forward_batches/(trainer.n_batches+1e-6)*
-                                                           trainer.n_epochs)
+                                                           completed=trainer.global_forward_batches / (
+                                                                   trainer.n_batches + 1e-6) *
+                                                                     trainer.n_epochs)
 
     def on_train_epoch_begin(self, trainer):
-        self.epoch_bar_update_advance = self.print_every/(trainer.num_batches_per_epoch + 1e-6)
+        self.epoch_bar_update_advance = self.print_every / (trainer.num_batches_per_epoch + 1e-6)
         if 'batch' in self.task2id:
             self.progress_bar.reset(self.task2id['batch'], completed=trainer.batch_idx_in_epoch)
         else:
@@ -137,27 +209,24 @@ class RichCallback(ProgressCallback):
 
         # 如果有额外的信息需要显示
         if self.extra_show_keys is not None:
-            if isinstance(self.extra_show_keys, str) and self.extra_show_keys in outputs:
-                self.extra_show_keys = {self.extra_show_keys: outputs[self.extra_show_keys]}
-            elif isinstance(self.extra_show_keys, list):
-                self.extra_show_keys = {key: outputs[key] for key in self.extra_show_keys if key in outputs}
-            elif isinstance(self.extra_show_keys, dict):
-                pass
-            elif callable(self.extra_show_keys):
-                self.extra_show_keys = self.extra_show_keys(outputs)
-
-            if not isinstance(self.extra_show_keys, dict):
-                self.extra_show_keys = dict()
+            if self.extra_info_collection is None or self.extra_info_model is None:
+                self.extra_info_collection = {key: value for key, value in outputs.items()
+                                              if key in self.extra_show_keys}
+            else:
+                self.extra_info_model.update(self.extra_info_collection, {key: value for key, value in outputs.items()
+                                                                          if key in self.extra_show_keys})
 
     def on_train_batch_end(self, trainer):
         if trainer.global_forward_batches % self.print_every == 0:
-            loss = self.loss/self.print_every
+            loss = self.loss / self.print_every
             self.loss = 0
             # 默认情况下进度条后只有 Loss 信息
             post_desc = f'Loss:{loss:.{self.loss_round_ndigit}f}'
             # 进度条后附加上用户希望的额外信息
-            if isinstance(self.extra_show_keys, dict):
-                post_desc = post_desc + ''.join([f"\n, {key}:{value}" for key, value in self.extra_show_keys.items()])
+            if self.extra_show_keys is not None:
+                post_desc = post_desc + _get_beautiful_extra_string(self.extra_info_model.get_stat(
+                    self.extra_info_collection, self.print_every), progress_type='rich')
+                self.extra_info_collection = None
             self.progress_bar.update(self.task2id['batch'], description=f'Batch:{trainer.batch_idx_in_epoch}',
                                      advance=self.print_every,
                                      post_desc=post_desc, refresh=True)
@@ -165,7 +234,7 @@ class RichCallback(ProgressCallback):
                                      advance=self.epoch_bar_update_advance, refresh=True)
 
     def on_evaluate_end(self, trainer, results):
-        if len(results)==0:
+        if len(results) == 0:
             return
         rule_style = ''
         text_style = ''
@@ -178,10 +247,10 @@ class RichCallback(ProgressCallback):
                     text_style = '[bold]'
                     characters = '+'
         self.progress_bar.print()
-        self.progress_bar.console.rule(text_style+f"Eval. results on Epoch:{trainer.cur_epoch_idx}, "
-                                                  f"Batch:{trainer.batch_idx_in_epoch}",
+        self.progress_bar.console.rule(text_style + f"Eval. results on Epoch:{trainer.cur_epoch_idx}, "
+                                                    f"Batch:{trainer.batch_idx_in_epoch}",
                                        style=rule_style, characters=characters)
-        results = {key:trainer.driver.tensor_to_numeric(value) for key, value in results.items() if
+        results = {key: trainer.driver.tensor_to_numeric(value) for key, value in results.items() if
                    not key.startswith('_')}
         if self.format_json:
             results = json.dumps(results)
@@ -223,16 +292,23 @@ class RawTextCallback(ProgressCallback):
 
         * 为 ``str``
          从 train_step 的返回 的 dict 中寻找该名称的内容，如果找到则打印出来。
-        * 为 ``List[str]``
+        * 为 ``Sequence[str]``
          与 ``str`` 类似，但是可以打印多个内容。
-        * 为 ``Dict[str, Any]``
-         将该参数原封不动地打印出来。
-        * 为 ``Callable``
-         用户可以自定义一个函数，接受参数为 train_step 的返回的 dict，返回一个 ``dict`` 作为需要打印的内容。
+
+    :param: extra_info_model: 当打印周期不为 1 的情况，是否希望额外打印的字段在打印周期间累积。
+
+        * 为 ``None``
+         不累积，仅打印当前轮次的额外信息
+        * 为静态类 :class:`~fastNLP.core.callback.BaseExtraInfoModel` 及其子类，必须实现 ``update`` 和 ``get_stat`` 方法。
+         在未进行打印的轮次，将额外信息相加累积，并在输出前求平均。可以手动重写 ``update`` 和 ``get_stat`` 方法来实现自己的累积方式。
 
     """
-    def __init__(self, print_every:int = 1, loss_round_ndigit:int = 6, monitor:str=None, larger_better:bool=True,
-                 format_json=True, extra_show_keys: Union[str, List[str], Dict[str, Any], Callable, None]=None):
+
+    def __init__(self, print_every: int = 1, loss_round_ndigit: int = 6, monitor: str = None,
+                 larger_better: bool = True,
+                 format_json=True,
+                 extra_show_keys: Union[str, Sequence[str], None] = None,
+                 extra_info_model: Union[type, None] = BaseExtraInfoModel):
         super().__init__(monitor=monitor, larger_better=larger_better, must_have_monitor=False)
         self.print_every = print_every
         self.task2id = {}
@@ -241,10 +317,18 @@ class RawTextCallback(ProgressCallback):
         self.set_monitor(monitor, larger_better)
         self.format_json = format_json
         self.num_signs = 10
-        self.extra_show_keys = extra_show_keys
+        # 用于在进度条中显示额外信息
+        self.extra_show_keys = extra_show_keys if isinstance(extra_show_keys, Sequence) or extra_show_keys is None \
+            else [extra_show_keys]
+        self.extra_info_model = extra_info_model
+        if not hasattr(self.extra_info_model, 'update') or not hasattr(self.extra_info_model, 'get_stat'):
+            logger.rank_zero_warning(f"Your manually defined ExtraInfoModel does not implement the method: \
+                    {', '.join([str(m) for m in ['update', 'get_stat'] if not hasattr(self.extra_info_model, m)])}.")
+            self.extra_info_model = BaseExtraInfoModel
+        self.extra_info_collection = None
 
     def on_train_epoch_begin(self, trainer):
-        logger.info('\n' + "*"*self.num_signs + f'Epoch:{trainer.cur_epoch_idx} starts' + '*'*self.num_signs)
+        logger.info('\n' + "*" * self.num_signs + f'Epoch:{trainer.cur_epoch_idx} starts' + '*' * self.num_signs)
 
     def on_before_backward(self, trainer, outputs):
         loss = trainer.extract_loss_from_outputs(outputs)
@@ -253,33 +337,31 @@ class RawTextCallback(ProgressCallback):
 
         # 如果有额外的信息需要显示
         if self.extra_show_keys is not None:
-            if isinstance(self.extra_show_keys, str) and self.extra_show_keys in outputs:
-                self.extra_show_keys = {self.extra_show_keys: outputs[self.extra_show_keys]}
-            elif isinstance(self.extra_show_keys, list):
-                self.extra_show_keys = {key: outputs[key] for key in self.extra_show_keys if key in outputs}
-            elif isinstance(self.extra_show_keys, dict):
-                pass
-            elif callable(self.extra_show_keys):
-                self.extra_show_keys = self.extra_show_keys(outputs)
-
-            if not isinstance(self.extra_show_keys, dict):
-                self.extra_show_keys = dict()
+            if self.extra_info_collection is None or self.extra_info_model is None:
+                self.extra_info_collection = {key: value for key, value in outputs.items()
+                                              if key in self.extra_show_keys}
+            else:
+                self.extra_info_model.update(self.extra_info_collection, {key: value for key, value in outputs.items()
+                                                                          if key in self.extra_show_keys})
 
     def on_train_batch_end(self, trainer):
         if trainer.global_forward_batches % self.print_every == 0:
-            loss = self.loss/self.print_every
+            loss = self.loss / self.print_every
             self.loss = 0
             # 默认情况下进度条后只有 Loss 信息
             post_desc = f'Loss:{loss:.{self.loss_round_ndigit}f}'
             # 进度条后附加上用户希望的额外信息
-            post_desc = post_desc + ''.join([f", {key}:{value}" for key, value in self.extra_show_keys.items()])
+            if self.extra_show_keys is not None:
+                post_desc = post_desc + _get_beautiful_extra_string(self.extra_info_model.get_stat(
+                    self.extra_info_collection, self.print_every), progress_type='raw')
+                self.extra_info_collection = None
             text = f'Epoch:{trainer.cur_epoch_idx}/{trainer.n_epochs}, Batch:{trainer.batch_idx_in_epoch}, ' \
                    + post_desc + \
-                   f', finished {round(trainer.global_forward_batches/trainer.n_batches*100, 2)}%.'
+                   f', finished {round(trainer.global_forward_batches / trainer.n_batches * 100, 2)}%.'
             logger.info(text)
 
     def on_evaluate_end(self, trainer, results):
-        if len(results)==0:
+        if len(results) == 0:
             return
         base_text = f'Eval. results on Epoch:{trainer.cur_epoch_idx}, Batch:{trainer.batch_idx_in_epoch}'
         text = ''
@@ -287,12 +369,12 @@ class RawTextCallback(ProgressCallback):
             if self.is_better_results(results, keep_if_better=True):
                 self.record_better_monitor(trainer, results)
                 if abs(self.monitor_value) != float('inf'):
-                    text = '+'*self.num_signs + base_text + '+'*self.num_signs
+                    text = '+' * self.num_signs + base_text + '+' * self.num_signs
         if len(text) == 0:
-            text = '-'*self.num_signs + base_text + '-'*self.num_signs
+            text = '-' * self.num_signs + base_text + '-' * self.num_signs
 
         logger.info(text)
-        results = {key:trainer.driver.tensor_to_numeric(value) for key, value in results.items() if
+        results = {key: trainer.driver.tensor_to_numeric(value) for key, value in results.items() if
                    not key.startswith('_')}
         if self.format_json:
             results = json.dumps(results)
@@ -327,15 +409,22 @@ class TqdmCallback(ProgressCallback):
 
         * 为 ``str``
          从 train_step 的返回 的 dict 中寻找该名称的内容，如果找到则打印出来。
-        * 为 ``List[str]``
+        * 为 ``Sequence[str]``
          与 ``str`` 类似，但是可以打印多个内容。
-        * 为 ``Dict[str, Any]``
-         将该参数原封不动地打印出来。
-        * 为 ``Callable``
-         用户可以自定义一个函数，接受参数为 train_step 的返回的 dict，返回一个 ``dict`` 作为需要打印的内容。
+
+    :param: extra_info_model: 当打印周期不为 1 的情况，是否希望额外打印的字段在打印周期间累积。
+
+        * 为 ``None``
+         不累积，仅打印当前轮次的额外信息
+        * 为静态类 :class:`~fastNLP.core.callback.BaseExtraInfoModel` 及其子类，必须实现 ``update`` 和 ``get_stat`` 方法。
+         在未进行打印的轮次，将额外信息相加累积，并在输出前求平均。可以手动重写 ``update`` 和 ``get_stat`` 方法来实现自己的累积方式。
     """
-    def __init__(self, print_every:int = 1, loss_round_ndigit:int = 6, monitor:str=None, larger_better:bool=True,
-                 format_json=True, extra_show_keys: Union[str, List[str], Dict[str, Any], Callable, None]=None):
+
+    def __init__(self, print_every: int = 1, loss_round_ndigit: int = 6, monitor: str = None,
+                 larger_better: bool = True,
+                 format_json=True,
+                 extra_show_keys: Union[str, Sequence[str], None] = None,
+                 extra_info_model: Union[type, None] = BaseExtraInfoModel):
         super().__init__(monitor=monitor, larger_better=larger_better, must_have_monitor=False)
         self.print_every = print_every
         self.progress_bar = f_tqdm_progress
@@ -344,16 +433,25 @@ class TqdmCallback(ProgressCallback):
         self.loss_round_ndigit = loss_round_ndigit
         self.format_json = format_json
         self.num_signs = 10
-        self.extra_show_keys = extra_show_keys
+        # 用于在进度条中显示额外信息
+        self.extra_show_keys = extra_show_keys if isinstance(extra_show_keys, Sequence) or extra_show_keys is None \
+            else [extra_show_keys]
+        self.extra_info_model = extra_info_model
+        if not hasattr(self.extra_info_model, 'update') or not hasattr(self.extra_info_model, 'get_stat'):
+            logger.rank_zero_warning(f"Your manually defined ExtraInfoModel does not implement the method: \
+                    {', '.join([str(m) for m in ['update', 'get_stat'] if not hasattr(self.extra_info_model, m)])}.")
+            self.extra_info_model = BaseExtraInfoModel
+        self.extra_info_collection = None
 
     def on_train_begin(self, trainer):
         self.task2id['epoch'] = self.progress_bar.add_task(description=f'Epoch:{trainer.cur_epoch_idx}',
                                                            total=trainer.n_epochs, dynamic_ncols=True,
-            bar_format='{desc}: {percentage:3.0f}%|{bar}| [{elapsed}<{remaining}, {rate_fmt}, {postfix}]',
-            initial=trainer.global_forward_batches/(trainer.n_batches+1e-6)*trainer.n_epochs)
+                                                           bar_format='{desc}: {percentage:3.0f}%|{bar}| [{elapsed}<{remaining}, {rate_fmt}, {postfix}]',
+                                                           initial=trainer.global_forward_batches / (
+                                                                   trainer.n_batches + 1e-6) * trainer.n_epochs)
 
     def on_train_epoch_begin(self, trainer):
-        self.epoch_bar_update_advance = self.print_every/(trainer.num_batches_per_epoch + 1e-6)
+        self.epoch_bar_update_advance = self.print_every / (trainer.num_batches_per_epoch + 1e-6)
         if 'batch' in self.task2id:
             self.progress_bar.reset(self.task2id['batch'])
         else:
@@ -372,31 +470,27 @@ class TqdmCallback(ProgressCallback):
 
         # 如果有额外的信息需要显示
         if self.extra_show_keys is not None:
-            if isinstance(self.extra_show_keys, str) and self.extra_show_keys in outputs:
-                self.extra_show_keys = {self.extra_show_keys: outputs[self.extra_show_keys]}
-            elif isinstance(self.extra_show_keys, list):
-                self.extra_show_keys = {key: outputs[key] for key in self.extra_show_keys if key in outputs}
-            elif isinstance(self.extra_show_keys, dict):
-                pass
-            elif callable(self.extra_show_keys):
-                self.extra_show_keys = self.extra_show_keys(outputs)
-            
-            if not isinstance(self.extra_show_keys, dict):
-                self.extra_show_keys = dict()
+            if self.extra_info_collection is None or self.extra_info_model is None:
+                self.extra_info_collection = {key: value for key, value in outputs.items()
+                                              if key in self.extra_show_keys}
+            else:
+                self.extra_info_model.update(self.extra_info_collection, {key: value for key, value in outputs.items()
+                                                                          if key in self.extra_show_keys})
 
     def on_train_batch_end(self, trainer):
         if trainer.global_forward_batches % self.print_every == 0:
-            loss = self.loss/self.print_every
+            loss = self.loss / self.print_every
             self.loss = 0
             # 默认情况下进度条后只有 Loss 信息
             post_desc = f'Loss:{loss:.{self.loss_round_ndigit}f}'
             # 进度条后附加上用户希望的额外信息
-            post_desc = post_desc + ''.join([f", {key}:{value}" for key, value in self.extra_show_keys.items()])
+            if self.extra_show_keys is not None:
+                post_desc = post_desc + _get_beautiful_extra_string(self.extra_info_model.get_stat(
+                    self.extra_info_collection, self.print_every), progress_type='tqdm')
+                self.extra_info_collection = None
             self.progress_bar.update(self.task2id['batch'], advance=self.print_every, refresh=True)
             self.progress_bar.set_postfix_str(self.task2id['batch'], post_desc)
             self.progress_bar.update(self.task2id['epoch'], advance=self.epoch_bar_update_advance, refresh=True)
-
-
 
     def on_evaluate_end(self, trainer, results):
         if len(results) == 0:
@@ -407,12 +501,12 @@ class TqdmCallback(ProgressCallback):
             if self.is_better_results(results, keep_if_better=True):
                 self.record_better_monitor(trainer, results)
                 if abs(self.monitor_value) != float('inf'):
-                    text = '+'*self.num_signs + base_text + '+'*self.num_signs
+                    text = '+' * self.num_signs + base_text + '+' * self.num_signs
         if len(text) == 0:
-            text = '-'*self.num_signs + base_text + '-'*self.num_signs
+            text = '-' * self.num_signs + base_text + '-' * self.num_signs
 
         logger.info(text)
-        results = {key:trainer.driver.tensor_to_numeric(value) for key, value in results.items() if
+        results = {key: trainer.driver.tensor_to_numeric(value) for key, value in results.items() if
                    not key.startswith('_')}
         if self.format_json:
             results = json.dumps(results)
@@ -427,3 +521,5 @@ class TqdmCallback(ProgressCallback):
     @property
     def name(self):  # progress bar的名称
         return 'tqdm'
+
+

--- a/fastNLP/core/utils/tqdm_progress.py
+++ b/fastNLP/core/utils/tqdm_progress.py
@@ -136,8 +136,8 @@ class TqdmProgress(metaclass=Singleton):
     def reset(self, task_id):
         self.bars[task_id].reset()
 
-    def print(self):
-        tqdm.write('')
+    def print(self, content: str = ''):
+        tqdm.write(content)
 
     def not_empty(self):
         return len(self.bars) != 0


### PR DESCRIPTION
Description：增加训练中进度条提供额外信息的能力

Main reason: 用户希望在控制台打印的进度条中增加额外的信息


Checklist  检查下面各项是否完成

Please feel free to remove inapplicable items for your PR.

-	[x] The PR title starts with [$CATEGORY] (例如[bugfix]修复bug，[new]添加新功能，[test]修改测试，[rm]删除旧代码)
-	[x] Changes are complete (i.e. I finished coding on this PR)  修改完成才提PR
-	[x] All changes have test coverage  修改的部分顺利通过测试。对于fastnlp/fastnlp/*的修改，测试代码**必须**提供在fastnlp/test/*。
-	[x] Code is well-documented  注释写好，API文档会从注释中抽取
-	[x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change  修改导致例子或tutorial有变化，请找核心开发人员

Changes: 逐项描述修改的内容
- 在 ProcessCallback 的构造函数增加新的字段 extra_show_keys，可以传入 str、List[str]、Callback、Dict类型的数据，将这样构造的 ProcessCallback 传入 Trainer 后，在打印进度条时会同时打印上述参数提供的额外信息。
