### PR TITLE
[new] 增加训练中进度条回调提供额外信息的能力

### DIFF
--- a/fastNLP/core/callbacks/__init__.py
+++ b/fastNLP/core/callbacks/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     'RichCallback',
     'TqdmCallback',
     'RawTextCallback',
+    'ExtraInfoStatistics',
 
     "LRSchedCallback",
     'LoadBestModelCallback',
@@ -34,7 +35,7 @@ from .callback import Callback
 from .callback_event import Event, Filter
 from .callback_manager import CallbackManager
 from .checkpoint_callback import CheckpointCallback
-from .progress_callback import choose_progress_callback, ProgressCallback, RichCallback, TqdmCallback, RawTextCallback
+from .progress_callback import choose_progress_callback, ProgressCallback, RichCallback, TqdmCallback, RawTextCallback, ExtraInfoStatistics
 from .lr_scheduler_callback import LRSchedCallback
 from .load_best_model_callback import LoadBestModelCallback
 from .early_stop_callback import EarlyStopCallback

--- a/tests/core/callbacks/test_progress_callback_torch.py
+++ b/tests/core/callbacks/test_progress_callback_torch.py
@@ -5,7 +5,8 @@ import pytest
 
 from fastNLP import Metric, Accuracy
 from tests.helpers.utils import magic_argv_env_context
-from fastNLP import Trainer, Evaluator
+from fastNLP import Trainer, Evaluator, RichCallback, RawTextCallback, TqdmCallback
+from fastNLP.core.callbacks import ExtraInfoStatistics
 from fastNLP.envs.imports import _NEED_IMPORT_TORCH
 if _NEED_IMPORT_TORCH:
     from torch.utils.data import DataLoader
@@ -118,6 +119,44 @@ def test_run( model_and_optimizers: TrainerParameters, device):
         dist.destroy_process_group()
 
 
+@pytest.mark.torch
+@pytest.mark.parametrize('device', ['cpu', [0, 1]])
+@magic_argv_env_context
+def test_show_extra_keys(model_and_optimizers: TrainerParameters, device):
+    if device != 'cpu' and not torch.cuda.is_available():
+        pytest.skip(f"No cuda for device:{device}")
+    n_epochs = 2
 
+    class MyExtraInfoStatistics(ExtraInfoStatistics):
+        def __init__(self):
+            super().__init__('loss')
 
+        def update(self, outputs) -> None:
+            pass
+
+        def get_stat(self) -> dict:
+            return dict(key1="value1", key2="value2")
+
+    for progress_callback_module in [RichCallback, RawTextCallback, TqdmCallback]:
+        progress_callback = progress_callback_module(extra_show_keys=MyExtraInfoStatistics())
+        trainer = Trainer(
+            model=model_and_optimizers.model,
+            driver='torch',
+            device=device,
+            optimizers=model_and_optimizers.optimizers,
+            train_dataloader=model_and_optimizers.train_dataloader,
+            evaluate_dataloaders=model_and_optimizers.evaluate_dataloaders,
+            input_mapping=model_and_optimizers.input_mapping,
+            output_mapping=model_and_optimizers.output_mapping,
+            metrics=model_and_optimizers.metrics,
+            n_epochs=n_epochs,
+            callbacks=[progress_callback],
+            output_from_new_proc="all",
+            evaluate_fn='train_step',
+            larger_better=False
+        )
+        trainer.run()
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
 


### PR DESCRIPTION
Description：增加训练中进度条回调提供额外信息。

Main reason: 用户希望在训练过程中可以获得除了 loss 外的模型的其他输出信息。


Checklist  检查下面各项是否完成

Please feel free to remove inapplicable items for your PR.

-	[x] The PR title starts with [$CATEGORY] (例如[bugfix]修复bug，[new]添加新功能，[test]修改测试，[rm]删除旧代码)
-	[x] Changes are complete (i.e. I finished coding on this PR)  修改完成才提PR
-	[x] All changes have test coverage  修改的部分顺利通过测试。对于fastnlp/fastnlp/*的修改，测试代码**必须**提供在fastnlp/test/*。
-	[x] Code is well-documented  注释写好，API文档会从注释中抽取
-	[x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change  修改导致例子或tutorial有变化，请找核心开发人员

Changes: 逐项描述修改的内容
- progress_callback 中为每个模型增加 extra_show_keys 参数，进度条回调会根据参数值提供的 key 去模型的返回结果中寻找对应的数据，并在更新进度条时显示出来。
- 对于打印周期大于一的情况，额外的数据也许也需要像 loss 一样有个类似周期间积累、打印前求平均的操作，因此实现了积累 BaseExtraInfoModel，用户可以重写其中的 update、get_stat 方法，分别对应积累过程、求平均过程。
- 对于额外信息过长而控制台过窄的情况，实现 _get_beautiful_extra_string 函数，对于使用 rich 进度条的情况可以让每个额外显示的值位于不同的行，防止进度条消失。

Mention: 找人review你的PR
