### PR TITLE
torch ddp多卡的情况下保证 Batch Norm 使用所有卡上的数据共同计算均值和方差

### DIFF
--- a/fastNLP/core/drivers/torch_driver/ddp.py
+++ b/fastNLP/core/drivers/torch_driver/ddp.py
@@ -158,7 +158,8 @@ from fastNLP.core.samplers import ReproducibleSampler, RandomSampler, Unrepeated
     re_instantiate_sampler, UnrepeatedSampler, conversion_between_reproducible_and_unrepeated_sampler
 from fastNLP.envs import FASTNLP_DISTRIBUTED_CHECK, FASTNLP_GLOBAL_RANK, FASTNLP_GLOBAL_SEED, FASTNLP_NO_SYNC
 from fastNLP.core.log import logger
-from fastNLP.core.drivers.torch_driver.dist_utils import fastnlp_torch_all_gather, fastnlp_torch_broadcast_object
+from fastNLP.core.drivers.torch_driver.dist_utils import fastnlp_torch_all_gather, fastnlp_torch_broadcast_object, \
+    convert_sync_batchnorm
 from .utils import _check_dataloader_args_for_distributed
 
 
@@ -243,6 +244,7 @@ class TorchDDPDriver(TorchDriver):
         * *gradscaler_kwargs* -- 用于 ``fp16=True`` 时，提供给 :class:`torch.amp.cuda.GradScaler` 的参数
     :kwargs:
         * *wo_auto_param_call* (``bool``) -- 是否关闭在训练时调用我们的 ``auto_param_call`` 函数来自动匹配 batch 和前向函数的参数的行为
+        * *sync_bn* (``bool``) -- 是否要将模型中可能存在的 BatchNorm 层转换为可同步所有卡数据计算均值和方差的 SyncBatchNorm 层
 
         .. note::
 
@@ -330,6 +332,8 @@ class TorchDDPDriver(TorchDriver):
 
         self._has_setup = False  # 设置这一参数是因为 evaluator 中也会进行 setup 操作，但是显然是不需要的也不应该的；
         self._has_ddpwrapped = False  # 判断传入的模型是否经过 _has_ddpwrapped 包裹；
+        # sync_bn 表示是否要将模型中可能存在的 BatchNorm 层转换为可同步所有卡数据计算均值和方差的 SyncBatchNorm 层；
+        self.sync_bn = kwargs.get("sync_bn", False)
 
     def setup(self):
         r"""
@@ -388,6 +392,9 @@ class TorchDDPDriver(TorchDriver):
 
         if not self.outside_ddp:
             self.configure_ddp()
+
+        if self.sync_bn:
+            self.model = convert_sync_batchnorm(self.model)
 
         self.barrier()
         # 初始化 self._pids，从而使得每一个进程都能接受到 rank0 的 send 操作；

--- a/fastNLP/core/drivers/torch_driver/ddp.py
+++ b/fastNLP/core/drivers/torch_driver/ddp.py
@@ -244,7 +244,7 @@ class TorchDDPDriver(TorchDriver):
         * *gradscaler_kwargs* -- 用于 ``fp16=True`` 时，提供给 :class:`torch.amp.cuda.GradScaler` 的参数
     :kwargs:
         * *wo_auto_param_call* (``bool``) -- 是否关闭在训练时调用我们的 ``auto_param_call`` 函数来自动匹配 batch 和前向函数的参数的行为
-        * *sync_bn* (``bool``) -- 是否要将模型中可能存在的 BatchNorm 层转换为可同步所有卡数据计算均值和方差的 SyncBatchNorm 层
+        * *sync_bn* (``bool``) -- 是否要将模型中可能存在的 BatchNorm 层转换为可同步所有卡数据计算均值和方差的 SyncBatchNorm 层，默认为 True
 
         .. note::
 
@@ -333,7 +333,7 @@ class TorchDDPDriver(TorchDriver):
         self._has_setup = False  # 设置这一参数是因为 evaluator 中也会进行 setup 操作，但是显然是不需要的也不应该的；
         self._has_ddpwrapped = False  # 判断传入的模型是否经过 _has_ddpwrapped 包裹；
         # sync_bn 表示是否要将模型中可能存在的 BatchNorm 层转换为可同步所有卡数据计算均值和方差的 SyncBatchNorm 层；
-        self.sync_bn = kwargs.get("sync_bn", False)
+        self.sync_bn = kwargs.get("sync_bn", True)
 
     def setup(self):
         r"""

--- a/fastNLP/core/drivers/torch_driver/dist_utils.py
+++ b/fastNLP/core/drivers/torch_driver/dist_utils.py
@@ -364,3 +364,27 @@ def all_gather_object(object_list, obj, group=None):
         tensor_size = object_size_list[i]
         object_list[i] = _tensor_to_object(tensor, tensor_size)
     return object_list
+
+
+def convert_sync_batchnorm(model, group=None):
+    """
+    将模型中所有继承 :class:`torch.nn.modules.batchnorm._BatchNorm` 的层转换为 :class:`torch.nn.SyncBatchNorm` 。
+
+    Example::
+        >>> import torch
+        >>> model = torch.nn.Sequential(
+        >>>     torch.nn.Linear(20, 100),
+        >>>     torch.nn.BatchNorm1d(100)
+        >>> ).cuda()
+        >>> process_group = torch.distributed.new_group(process_ids)
+        >>> model = convert_sync_batchnorm(model, process_group)
+        >>> # also works with nn.DataParallel
+        >>> model = torch.nn.parallel.DistributedDataParallel(model)
+        >>> model = convert_sync_batchnorm(model, process_group)
+
+    :param model: 要转换的模型
+    :param process_group: 同步的进程组，如果为None，则使用默认的进程组。
+    :return: 转换后的模型
+
+    """
+    return torch.nn.SyncBatchNorm.convert_sync_batchnorm(model, process_group=group)

--- a/tests/core/drivers/torch_driver/test_ddp.py
+++ b/tests/core/drivers/torch_driver/test_ddp.py
@@ -1058,7 +1058,7 @@ def test_customized_sampler_dataloader(inherit):
 
 @pytest.mark.torch
 @magic_argv_env_context
-@pytest.mark.parametrize("device", ([[0, 1, 2]]))
+@pytest.mark.parametrize("device", (['cpu', 0, [0, 1]]))
 def test_sync_batchnorm(device):
     import numpy as np
     from fastNLP import Event, Trainer, DataSet, Instance
@@ -1078,6 +1078,9 @@ def test_sync_batchnorm(device):
 
     @Trainer.on(Event.on_train_batch_end())
     def check_sync(trainer):
+        if not isinstance(device, list) or len(device) is 0:
+            # 单卡或 CPU 的情况下不需要检查
+            return
         running_mean_list = fastnlp_torch_all_gather(trainer.model.norm.running_mean)
         running_var_list = fastnlp_torch_all_gather(trainer.model.norm.running_var)
         for running_mean in running_mean_list:


### PR DESCRIPTION
Description：torch ddp多卡的情况下保证 Batch Norm 使用所有卡上的数据共同计算均值和方差。

Main reason: 在使用 torch dpp 多卡的时候，BatchNorm 层默认值使用自己卡上的数据计算均值和方差然后进行归一化，导致不同卡上计算得到的均值和方差不同，可能会使训练变得不稳定。


Checklist  检查下面各项是否完成

Please feel free to remove inapplicable items for your PR.

-	[x] The PR title starts with [$CATEGORY] (例如[bugfix]修复bug，[new]添加新功能，[test]修改测试，[rm]删除旧代码)
-	[x] Changes are complete (i.e. I finished coding on this PR)  修改完成才提PR
-	[x] All changes have test coverage  修改的部分顺利通过测试。对于fastnlp/fastnlp/*的修改，测试代码**必须**提供在fastnlp/test/*。
-	[x] Code is well-documented  注释写好，API文档会从注释中抽取
-	[x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change  修改导致例子或tutorial有变化，请找核心开发人员

Changes: 逐项描述修改的内容
- fastNLP/core/drivers/torch_driver/dist_utils 中增加了 convert_sync_batchnorm 方法，当 ddp 得到参数 sync_bn=True (例如在 Trainer 的参数中指定 sync_bn=True) 时，可以把模型中所有的 BatchNorm 层替换成 torch 实现好的 SyncBatchNorm 层。
