### PR TITLE
from_dataset ignore null instance

### DIFF
--- a/fastNLP/core/vocabulary.py
+++ b/fastNLP/core/vocabulary.py
@@ -396,6 +396,10 @@ class Vocabulary(object):
         def construct_vocab(ins, no_create_entry=False):
             for fn in field_name:
                 field = ins[fn]
+                 # 如果 field 为空或者 None， 那么直接跳过即可。
+                if field is None or len(field) == 0:
+                    logger.warning(f"instance: {ins} has null field. Skip now!") 
+                    continue
                 if isinstance(field, str) or not _is_iterable(field):
                     self.add_word(field, no_create_entry=no_create_entry)
                 else:

--- a/fastNLP/core/vocabulary.py
+++ b/fastNLP/core/vocabulary.py
@@ -397,7 +397,7 @@ class Vocabulary(object):
             for fn in field_name:
                 field = ins[fn]
                  # 如果 field 为空或者 None， 那么直接跳过即可。
-                if field is None or len(field) == 0:
+                if field is None or (hasattr(field, "__len__") and len(field) == 0):
                     logger.warning(f"instance: {ins} has null field. Skip now!") 
                     continue
                 if isinstance(field, str) or not _is_iterable(field):

--- a/tests/core/test_vocabulary.py
+++ b/tests/core/test_vocabulary.py
@@ -1,0 +1,15 @@
+import pytest
+from collections import Counter
+
+from fastNLP.core.dataset import DataSet
+from fastNLP.core.vocabulary import Vocabulary
+from fastNLP import logger
+
+
+class TestVocabulary:
+
+    def test_from_dataset(self):
+        ds = DataSet({"x": [[1, 2], [3, 4]], "y": ["apple", ""]})
+        vocab = Vocabulary()
+        vocab.from_dataset(ds, field_name="y")
+        assert vocab.word_count == Counter({'apple': 1})

--- a/tests/core/test_vocabulary.py
+++ b/tests/core/test_vocabulary.py
@@ -13,3 +13,9 @@ class TestVocabulary:
         vocab = Vocabulary()
         vocab.from_dataset(ds, field_name="y")
         assert vocab.word_count == Counter({'apple': 1})
+    
+    def test_from_dataset1(self):
+        ds = DataSet({"x": [[1, 2], [3, 4], [5]], "y": [1, None, 2]})
+        vocab = Vocabulary()
+        vocab.from_dataset(ds, field_name="y")
+        assert vocab.word_count == Counter({1: 1, 2: 1})


### PR DESCRIPTION
Description：简要描述这次PR的内容
vocaburary的from_datasets支持某个instance存在空字符串。会跳过并打印warning信息。增加对应的测试用例

Main reason: 做出这次修改的原因


Checklist  检查下面各项是否完成

Please feel free to remove inapplicable items for your PR.

-	[ ] The PR title starts with [$CATEGORY] (例如[bugfix]修复bug，[new]添加新功能，[test]修改测试，[rm]删除旧代码)
-	[ ] Changes are complete (i.e. I finished coding on this PR)  修改完成才提PR
-	[ ] All changes have test coverage  修改的部分顺利通过测试。对于fastnlp/fastnlp/*的修改，测试代码**必须**提供在fastnlp/test/*。
-	[ ] Code is well-documented  注释写好，API文档会从注释中抽取
-	[ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change  修改导致例子或tutorial有变化，请找核心开发人员

Changes: 逐项描述修改的内容
- 添加了新模型；用于句子分类的CNN，来自Yoon Kim的Convolutional Neural Networks for Sentence Classification
- 修改dataset.py中过时的和不合规则的注释 #286
- 添加对var-LSTM的测试代码

Mention: 找人review你的PR

@修改过这个文件的人
@核心开发人员
